### PR TITLE
fix: Splash's `darkThemeBackgroundColor` is different from the one used in navbar background

### DIFF
--- a/patches/src/main/kotlin/app/revanced/patches/bilibili/misc/splash/SplashPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/bilibili/misc/splash/SplashPatch.kt
@@ -26,8 +26,9 @@ object SplashPatch : ResourcePatch() {
 
     private val darkThemeBackgroundColor by stringPatchOption(
         key = "darkThemeBackgroundColor",
-        default = BLACK_COLOR,
+        default = "#FF17181A",
         values = mapOf(
+            "Black" to "#FF17181A",
             "Amoled black" to BLACK_COLOR,
             "Material You" to "@android:color/system_neutral1_900",
             "Classic (old YouTube)" to "#FF212121",


### PR DESCRIPTION
| Before | After |
| :----- | :-----| 
| ![Screenshot_20240601-090744](https://github.com/BiliRoamingX/BiliRoamingX/assets/93428659/83efe708-f442-4b40-9db5-5afe507f27a0) | ![Screenshot_20240601-085003](https://github.com/BiliRoamingX/BiliRoamingX/assets/93428659/7bc3baa4-db9c-4480-a607-51d9256da176) |
